### PR TITLE
Update repository URL

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -6,5 +6,5 @@ bundle_id = org.laptop.community.Finance
 icon = Finance-activity
 exec = sugar-activity finance.Finance
 summary = Want to wisely manage money? Learn financial planning basics and track your family's finance, make your own budget and learn how to make every penny count!
-repository = git@github.com:godiard/finance-activity.git
+repository = https://github.com/sugarlabs/finance-activity
 max_participants = 1


### PR DESCRIPTION
- use HTTPS transport, fixes `git clone` on systems that don't have an SSH key for github.com,
- follow recent redirect from `godiard/` to `sugarlabs/`
