### PR TITLE
[Fix]: Help Button Error on Mouse Click

### DIFF
--- a/helpbutton.py
+++ b/helpbutton.py
@@ -62,7 +62,7 @@ class HelpButton(Gtk.ToolItem):
         help_button.connect('clicked', self.__help_button_clicked_cb)
 
     def __help_button_clicked_cb(self, button):
-        self._palette.popup(immediate=True, state=1)
+        self._palette.popup(immediate=True)
 
     def add_section(self, section_text, icon=None):
         hbox = Gtk.Box()


### PR DESCRIPTION
Clicking `help` button raised this error:

```
popup() got an unexpected keyword argument 'state'
```

The same is fixed in this PR